### PR TITLE
Removing spammed "closed" output

### DIFF
--- a/src/uploader.coffee
+++ b/src/uploader.coffee
@@ -65,7 +65,6 @@ class Uploader extends EventEmitter
         @flushPart()
 
     stream.on 'error', (err) -> @failed = true
-    stream.on 'close', -> console.error 'closed'
     stream.on 'end', =>
       @receivedAllData = true
       if @initiated


### PR DESCRIPTION
There is no need for the plugin to spam "closed" to the console every time a streaming connection to S3 ends. This removes the stderr output that was happening at the end of every upload.
