### PR TITLE
@objectName => @objectParams.Key

### DIFF
--- a/src/uploader.coffee
+++ b/src/uploader.coffee
@@ -143,7 +143,7 @@ class Uploader extends EventEmitter
         chunk.client.uploadPart
           Body:       chunk
           Bucket:     @objectParams.Bucket
-          Key:        @objectName
+          Key:        @objectParams.Key
           PartNumber: chunk.partNumber.toString()
           UploadId:   @uploadId
         , (err, data) =>


### PR DESCRIPTION
Sometimes objectName and objectParams.Key are identical, but not always (see line 19)

**I'm not sure if this change is correct, but reading through the code this looked like a mistake.**
