### PR TITLE
Copies objectParams per-instance (Fixes #57)

### DIFF
--- a/src/uploader.coffee
+++ b/src/uploader.coffee
@@ -12,17 +12,22 @@ class Uploader extends EventEmitter
       sessionToken:    sessionToken
       region:          region if region
 
+    params =
+      Bucket: bucket
+      Key: objectName
+      Body: stream
+
+    for k of objectParams or {}
+      params[k] ||= objectParams[k]
+
     @objectName           = objectName
-    @objectParams         = objectParams or {}
-    @objectParams.Bucket ?= bucket
-    @objectParams.Key    ?= objectName
-    @objectParams.Body   ?= stream
+    @objectParams         = params
     @timeout              = 300000
     @debug                = debug or false
 
     throw new Error "Bucket must be given" unless @objectParams.Bucket
 
-    @upload = new aws.S3.ManagedUpload { partSize: 10 * 1024 * 1024, queueSize: 1, service: service, params: @objectParams }
+    @upload = new aws.S3.ManagedUpload { partSize: 10 * 1024 * 1024, queueSize: 1, service: service, params: params }
     @upload.minPartSize = 1024 * 1024 * 5
     @upload.queueSize   = 4
     # Progress event

--- a/test/uploader-test.coffee
+++ b/test/uploader-test.coffee
@@ -5,6 +5,9 @@ describe 'Setup file upload test', ->
   source = undefined
   uploader  = undefined
 
+  objectParams =
+    ContentType: 'text/csv'
+
   before (done) ->
     source = new Buffer "key;value\ntest;1\nexample;2\n"
 
@@ -13,9 +16,8 @@ describe 'Setup file upload test', ->
       secretKey: "test-secretKey"
       bucket:    "test-bucket"
       objectName: "testfile1"
+      objectParams: objectParams
       stream: source
-      objectParams:
-        ContentType: 'text/csv'
       debug: true
     done()
 
@@ -33,3 +35,18 @@ describe 'Setup file upload test', ->
 
   it 'I have set debug', ->
     assert.ok uploader.debug
+
+  describe 'Creating a second uploader', ->
+    uploader2 = undefined
+
+    before () =>
+      uploader2 = new Uploader
+        bucket: 'test-bucket-2'
+        stream: new Buffer '...\n'
+        objectParams: objectParams
+
+    it 'I have set bucket', ->
+      assert.equal uploader2.objectParams.Bucket, 'test-bucket-2'
+
+    it 'I have not unset original bucket', ->
+      assert.equal uploader.objectParams.Bucket, 'test-bucket'


### PR DESCRIPTION
Stops changes to `objectParams` from leaking out of the `Uploader`
constructor.